### PR TITLE
DS2998- Backfill aua tables with att data

### DIFF
--- a/backfill/2023-08-03-fenix_active_users_aggregates_v1/README.md
+++ b/backfill/2023-08-03-fenix_active_users_aggregates_v1/README.md
@@ -7,12 +7,12 @@
 ## Context
 
 AS per DENG-2998 it was decided to add attribution data to active users aggregates table. However, the traditional backfill via airflow would affect the aua numbers due to shredder's impact. Hence it was decided to leverage `unified metrics` (which is not impacted by shredder)
-to populate temporary active users aggregates table `fenix_aua_with_att_historical_2021-01-01_2023-08-02` and swap the `fenix_derived.active_users_aggregates_v1` with the temp table.
+to populate temporary active users aggregates table `fenix_aua_with_att_historical` and swap the `fenix_derived.active_users_aggregates_v1` with the temp table.
 
-## Step 1:  Populate  `fenix_aua_with_att_historical_2021-01-01_2023-08-02` using the `query.sql`
+## Step 1:  Populate  `fenix_aua_with_att_historical` using the `query.sql`
 
-## Step 3:  Validate that both tables are exact match.
+## Step 2:  Validate that both tables are exact match.
 
-## Step 2: Take snapshot of `fenix_derived.active_users_aggregates_v1` (set to expire after a month)
+## Step 3: Take snapshot of `fenix_derived.active_users_aggregates_v1` (set to expire after a month) or alternatively bump the version of the table which requires minimal/ no intervention from DSRE
 
-## Step 4: Drop `fenix_derived.active_users_aggregates_v1` and rename `fenix_aua_with_att_historical_2021-01-01_2023-08-02` to `fenix_derived.active_users_aggregates_v1` might need SRE support.
+## Step 4: Rename `fenix_aua_with_att_historical` to `fenix_derived.active_users_aggregates_v1` might need SRE support and deprecate `firefox_desktop_derived.active_users_aggregates_v1`

--- a/backfill/2023-08-03-fenix_active_users_aggregates_v1/README.md
+++ b/backfill/2023-08-03-fenix_active_users_aggregates_v1/README.md
@@ -1,0 +1,18 @@
+# Backfill fenix active users aggregates between 2021-01-01 and 2023-08-02
+
+  - [DENG-2998](https://mozilla-hub.atlassian.net/browse/DS-2998): Add attribution data to active users aggregates
+  - GCP project used:  `moz-fx-data-shared-prod.analysis`
+
+
+## Context
+
+AS per DENG-2998 it was decided to add attribution data to active users aggregates table. However, the traditional backfill via airflow would affect the aua numbers due to shredder's impact. Hence it was decided to leverage `unified metrics` (which is not impacted by shredder)
+to populate temporary active users aggregates table `fenix_aua_with_att_historical_2021-01-01_2023-08-02` and swap the `fenix_derived.active_users_aggregates_v1` with the temp table.
+
+## Step 1:  Populate  `fenix_aua_with_att_historical_2021-01-01_2023-08-02` using the `query.sql`
+
+## Step 3:  Validate that both tables are exact match.
+
+## Step 2: Take snapshot of `fenix_derived.active_users_aggregates_v1` (set to expire after a month)
+
+## Step 4: Drop `fenix_derived.active_users_aggregates_v1` and rename `fenix_aua_with_att_historical_2021-01-01_2023-08-02` to `fenix_derived.active_users_aggregates_v1` might need SRE support.

--- a/backfill/2023-08-03-fenix_active_users_aggregates_v1/query.sql
+++ b/backfill/2023-08-03-fenix_active_users_aggregates_v1/query.sql
@@ -1,0 +1,118 @@
+WITH baseline_attribution_data AS (
+  SELECT
+    activity_segment AS segment,
+    attribution_medium,
+    attribution_source,
+    attribution_medium IS NOT NULL
+    OR attribution_source IS NOT NULL AS attributed,
+    city,
+    country,
+    distribution_id,
+    EXTRACT(YEAR FROM um.first_seen_date) AS first_seen_year,
+    is_default_browser,
+    channel,
+    normalized_os AS os,
+    os_version,
+    os_version_major,
+    os_version_minor,
+    um.submission_date,
+    um.locale,
+    att.adjust_network,
+    att.install_source,
+    um.first_seen_date,
+    normalized_app_name as app_name,
+    normalized_os,
+    days_since_seen,
+    ad_click,
+    organic_search_count,
+    search_count,
+    search_with_ads,
+    uri_count,
+    active_hours_sum,
+    um.app_version as app_version,
+    um.client_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry.unified_metrics` AS um
+  LEFT JOIN
+    fenix.firefox_android_clients AS att
+  ON
+    um.client_id = att.client_id
+  WHERE
+    um.submission_date BETWEEN '2021-01-01' AND '2023-08-02' and normalized_app_name = 'Fenix'
+),
+enriched_with_language AS 
+(
+   SELECT
+    baseline_attribution_data.* EXCEPT (locale),
+    CASE
+      WHEN locale IS NOT NULL
+        AND languages.language_name IS NULL
+        THEN 'Other'
+      ELSE languages.language_name
+    END AS language_name,
+  FROM
+    baseline_attribution_data
+  LEFT JOIN
+    `mozdata.static.csa_gblmkt_languages` AS languages
+  ON
+    baseline_attribution_data.locale = languages.code
+),
+
+final_attribution_data AS (SELECT
+  segment,
+  app_version,
+  attribution_medium,
+  attribution_source,
+  attributed,
+  city,
+  country,
+  distribution_id,
+  first_seen_year,
+  is_default_browser,
+  app_name,
+  channel,
+  os,
+  os_version,
+  os_version_major,
+  os_version_minor,
+  submission_date,
+  adjust_network,
+  install_source,
+  language_name,
+  COUNT(DISTINCT IF(days_since_seen = 0, client_id, NULL)) AS dau,
+  COUNT(DISTINCT IF(days_since_seen < 7, client_id, NULL)) AS wau,
+  COUNT(DISTINCT client_id) AS mau,
+  COUNT(DISTINCT IF(submission_date = first_seen_date, client_id, NULL)) AS new_profiles,
+  SUM(ad_click) AS ad_clicks,
+  SUM(organic_search_count) AS organic_search_count,
+  SUM(search_count) AS search_count,
+  SUM(search_with_ads) AS search_with_ads,
+  SUM(uri_count) AS uri_count,
+  SUM(active_hours_sum) AS active_hours
+FROM
+  enriched_with_language
+GROUP BY
+  segment,
+  distribution_id,
+  channel,
+  os_version,
+  os_version_major,
+  os_version_minor,
+  language_name,
+  app_name,
+  app_version,
+  attributed,
+  attribution_medium,
+  attribution_source,
+  adjust_network,
+  install_source,
+  city,
+  country,
+  first_seen_year,
+  is_default_browser,
+  app_name,
+  os,
+  submission_date
+)
+
+select * from final_attribution_data

--- a/backfill/2023-08-03-fenix_active_users_aggregates_v1/query.sql
+++ b/backfill/2023-08-03-fenix_active_users_aggregates_v1/query.sql
@@ -36,7 +36,7 @@ WITH baseline_attribution_data AS (
   LEFT JOIN
     fenix.firefox_android_clients AS att
   ON
-    um.client_id = att.client_id
+    um.client_id = att.client_id 
   WHERE
     um.submission_date BETWEEN '2021-01-01' AND '2023-08-02' and normalized_app_name = 'Fenix'
 ),

--- a/backfill/2023-08-03-firefox_desktop_active_users_aggregates_v1/README.md
+++ b/backfill/2023-08-03-firefox_desktop_active_users_aggregates_v1/README.md
@@ -1,0 +1,19 @@
+# Backfill firefox desktop active users aggregates between 2021-01-01 and 2023-08-02
+
+  - [DENG-2998](https://mozilla-hub.atlassian.net/browse/DS-2998): Add attribution data to active users aggregates
+  - GCP project used:  `moz-fx-data-shared-prod.analysis`
+
+
+## Context
+
+AS per DENG-2998 it was decided to add attribution data to active users aggregates table. However, the traditional backfill via airflow would affect the aua numbers due to shredder's impact. Hence it was decided to leverage `unified metrics` (which is not impacted by shredder)
+to populate temporary active users aggregates table `firefox_dekstop_aua_with_att_historical_2021-01-01_2023-08-02` and swap the `firefox_desktop_derived.active_users_aggregates_v1` with the temp table.
+
+## Step 1:  Populate  `firefox_dekstop_aua_with_att_historical_2021-01-01_2023-08-02` using the `query.sql`
+
+## Step 2: Take snapshot of `firefox_desktop_derived.active_users_aggregates_v1` (set to expire after a month)
+
+## Step 3:  Validate that both tables are exact match.
+
+
+## Step 4: Drop `firefox_desktop_derived.active_users_aggregates_v1` and rename `firefox_dekstop_aua_with_att_historical_2021-01-01_2023-08-02` to `firefox_desktop_derived.active_users_aggregates_v1` might need SRE support.

--- a/backfill/2023-08-03-firefox_desktop_active_users_aggregates_v1/README.md
+++ b/backfill/2023-08-03-firefox_desktop_active_users_aggregates_v1/README.md
@@ -7,13 +7,12 @@
 ## Context
 
 AS per DENG-2998 it was decided to add attribution data to active users aggregates table. However, the traditional backfill via airflow would affect the aua numbers due to shredder's impact. Hence it was decided to leverage `unified metrics` (which is not impacted by shredder)
-to populate temporary active users aggregates table `firefox_dekstop_aua_with_att_historical_2021-01-01_2023-08-02` and swap the `firefox_desktop_derived.active_users_aggregates_v1` with the temp table.
+to populate temporary active users aggregates table `firefox_dekstop_aua_with_att_historical` and swap the `firefox_desktop_derived.active_users_aggregates_v1` with the temp table.
 
-## Step 1:  Populate  `firefox_dekstop_aua_with_att_historical_2021-01-01_2023-08-02` using the `query.sql`
+## Step 1:  Populate  `firefox_dekstop_aua_with_att_historical` using the `query.sql`
 
-## Step 2: Take snapshot of `firefox_desktop_derived.active_users_aggregates_v1` (set to expire after a month)
+## Step 2:  Validate that both tables are exact match.
 
-## Step 3:  Validate that both tables are exact match.
+## Step 3: Take snapshot of `firefox_desktop_derived.active_users_aggregates_v1` (set to expire after a month) or alternatively bump the version of the table which requires minimal/ no intervention from DSRE
 
-
-## Step 4: Drop `firefox_desktop_derived.active_users_aggregates_v1` and rename `firefox_dekstop_aua_with_att_historical_2021-01-01_2023-08-02` to `firefox_desktop_derived.active_users_aggregates_v1` might need SRE support.
+## Step 4: Rename `firefox_dekstop_aua_with_att_historical` to `firefox_desktop_derived.active_users_aggregates_v2` might need SRE support and deprecate `firefox_desktop_derived.active_users_aggregates_v1`

--- a/backfill/2023-08-03-firefox_desktop_active_users_aggregates_v1/query.sql
+++ b/backfill/2023-08-03-firefox_desktop_active_users_aggregates_v1/query.sql
@@ -1,0 +1,125 @@
+WITH baseline_attribution_data AS (
+  SELECT
+    activity_segment AS segment,
+    normalized_app_name AS app_name,
+    app_version,
+    normalized_channel AS channel,
+    country,
+    city,
+    EXTRACT(YEAR FROM first_seen_date) AS first_seen_year,
+    first_seen_date,
+    normalized_os AS os,
+    normalized_os_version AS os_version,
+    COALESCE(
+      CAST(NULLIF(SPLIT(normalized_os_version, ".")[SAFE_OFFSET(0)], "") AS INTEGER),
+      0
+    ) AS os_version_major,
+    COALESCE(
+      CAST(NULLIF(SPLIT(normalized_os_version, ".")[SAFE_OFFSET(1)], "") AS INTEGER),
+      0
+    ) AS os_version_minor,
+    submission_date,
+    is_default_browser,
+    distribution_id,
+    attribution_source,
+    attribution_medium,
+    attribution_medium IS NOT NULL
+    OR attribution_source IS NOT NULL AS attributed,
+    attribution_campaign,
+    attribution_content,
+    attribution_experiment,
+    attribution_variation,
+    days_since_seen,
+    ad_click,
+    organic_search_count,
+    search_count,
+    search_with_ads,
+    uri_count,
+    active_hours_sum,
+    um.client_id,
+    locale
+  FROM
+    `moz-fx-data-shared-prod.telemetry.unified_metrics` AS um
+  WHERE
+    um.submission_date BETWEEN '2021-01-01' AND '2023-08-02' and normalized_app_name = 'Firefox Desktop'
+),
+enriched_with_language AS 
+(
+   SELECT
+    baseline_attribution_data.* EXCEPT (locale),
+    CASE
+      WHEN locale IS NOT NULL 
+        AND languages.language_name IS NULL
+        THEN 'Other'
+      ELSE languages.language_name
+    END AS language_name,
+  FROM
+    baseline_attribution_data
+  LEFT JOIN
+    `mozdata.static.csa_gblmkt_languages` AS languages
+  ON
+    baseline_attribution_data.locale = languages.code
+),
+
+final_attribution_data AS (SELECT
+  segment,
+  app_name,
+  app_version,
+  channel,
+  country,
+  city,
+  first_seen_year,
+  os,
+  os_version,
+  os_version_major,
+  os_version_minor,
+  submission_date,
+  is_default_browser,
+  distribution_id,
+  attribution_medium,
+  attribution_source,
+  attributed,
+  attribution_campaign,
+  attribution_content,
+  attribution_experiment,
+  attribution_variation,
+  language_name,
+  COUNT(DISTINCT IF(days_since_seen = 0, client_id, NULL)) AS dau,
+  COUNT(DISTINCT IF(days_since_seen < 7, client_id, NULL)) AS wau,
+  COUNT(DISTINCT client_id) AS mau,
+  COUNT(DISTINCT IF(submission_date = first_seen_date, client_id, NULL)) AS new_profiles,
+  SUM(ad_click) AS ad_clicks,
+  SUM(organic_search_count) AS organic_search_count,
+  SUM(search_count) AS search_count,
+  SUM(search_with_ads) AS search_with_ads,
+  SUM(uri_count) AS uri_count,
+  SUM(active_hours_sum) AS active_hours
+FROM
+  enriched_with_language
+GROUP BY
+  segment,
+  distribution_id,
+  channel,
+  os_version,
+  os_version_major,
+  os_version_minor,
+  language_name,
+  app_name,
+  app_version,
+  attributed,
+  attribution_medium,
+  attribution_source,
+  city,
+  country,
+  first_seen_year,
+  is_default_browser,
+  app_name,
+  os,
+  submission_date,
+  attribution_campaign,
+  attribution_content,
+  attribution_experiment,
+  attribution_variation
+)
+
+select * from final_attribution_data

--- a/backfill/2023-08-03-firefox_ios_active_users_aggregates_v1/README.md
+++ b/backfill/2023-08-03-firefox_ios_active_users_aggregates_v1/README.md
@@ -1,0 +1,19 @@
+# Backfill firefox ios active users aggregates between 2021-01-01 and 2023-08-02
+
+  - [DENG-2998](https://mozilla-hub.atlassian.net/browse/DS-2998): Add attribution data to active users aggregates
+  - GCP project used:  `moz-fx-data-shared-prod.analysis`
+
+
+## Context
+
+AS per DENG-2998 it was decided to add attribution data to active users aggregates table. However, the traditional backfill via airflow would affect the aua numbers due to shredder's impact. Hence it was decided to leverage `unified metrics` (which is not impacted by shredder)
+to populate temporary active users aggregates table `firefox_ios_aua_with_att_historical_2021-01-01_2023-08-02` and swap the `firefox_ios.active_users_aggregates_v1` with the temp table.
+
+## Step 1:  Populate  `firefox_ios_aua_with_att_historical_2021-01-01_2023-08-02` using the 
+
+## Step 2: Take snapshot of `firefox_ios.active_users_aggregates_v1` (set to expire after a month)
+
+## Step 3:  Validate that both tables are exact match.
+
+
+## Step 4: Drop `firefox_ios.active_users_aggregates_v1` and rename `firefox_ios_aua_with_att_historical_2021-01-01_2023-08-02` to `firefox_ios.active_users_aggregates_v1` might need SRE support.

--- a/backfill/2023-08-03-firefox_ios_active_users_aggregates_v1/README.md
+++ b/backfill/2023-08-03-firefox_ios_active_users_aggregates_v1/README.md
@@ -7,13 +7,13 @@
 ## Context
 
 AS per DENG-2998 it was decided to add attribution data to active users aggregates table. However, the traditional backfill via airflow would affect the aua numbers due to shredder's impact. Hence it was decided to leverage `unified metrics` (which is not impacted by shredder)
-to populate temporary active users aggregates table `firefox_ios_aua_with_att_historical_2021-01-01_2023-08-02` and swap the `firefox_ios.active_users_aggregates_v1` with the temp table.
+to populate temporary active users aggregates table `firefox_ios_aua_with_att_historical` and swap the `firefox_ios.active_users_aggregates_v1` with the temp table.
 
-## Step 1:  Populate  `firefox_ios_aua_with_att_historical_2021-01-01_2023-08-02` using the 
+## Step 1:  Populate  `firefox_ios_aua_with_att_historical` using the  `query.sql`
 
-## Step 2: Take snapshot of `firefox_ios.active_users_aggregates_v1` (set to expire after a month)
+## Step 2:  Validate that both tables are exact match.
 
-## Step 3:  Validate that both tables are exact match.
+## Step 3: Take snapshot of `firefox_ios.active_users_aggregates_v1` (set to expire after a month) or alternatively bump the version of the table which requires minimal/ no intervention from DSRE
 
 
-## Step 4: Drop `firefox_ios.active_users_aggregates_v1` and rename `firefox_ios_aua_with_att_historical_2021-01-01_2023-08-02` to `firefox_ios.active_users_aggregates_v1` might need SRE support.
+## Step 4: Rename `firefox_ios_aua_with_att_historical` to `firefox_ios.active_users_aggregates_v1` might need SRE support and deprecate `firefox_ios.active_users_aggregates_v1`

--- a/backfill/2023-08-03-firefox_ios_active_users_aggregates_v1/query.sql
+++ b/backfill/2023-08-03-firefox_ios_active_users_aggregates_v1/query.sql
@@ -1,0 +1,118 @@
+WITH baseline_attribution_data AS (
+  SELECT
+    activity_segment AS segment,
+    attribution_medium,
+    attribution_source,
+    attribution_medium IS NOT NULL
+    OR attribution_source IS NOT NULL AS attributed,
+    city,
+    country,
+    distribution_id,
+    EXTRACT(YEAR FROM um.first_seen_date) AS first_seen_year,
+    is_default_browser,
+    channel,
+    normalized_os AS os,
+    os_version,
+    os_version_major,
+    os_version_minor,
+    um.submission_date,
+    um.locale,
+    att.adjust_network,
+    CAST(NULL AS STRING) install_source,
+    um.first_seen_date,
+    normalized_app_name as app_name,
+    normalized_os,
+    days_since_seen,
+    ad_click,
+    organic_search_count,
+    search_count,
+    search_with_ads,
+    uri_count,
+    active_hours_sum,
+    um.app_version as app_version,
+    um.client_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry.unified_metrics` AS um
+  LEFT JOIN
+    firefox_ios.firefox_ios_clients AS att
+  ON
+    um.client_id = att.client_id
+  WHERE
+    um.submission_date BETWEEN '2021-01-01' AND '2023-08-02' and normalized_app_name = 'Firefox iOS'
+),
+enriched_with_language AS 
+(
+   SELECT
+    baseline_attribution_data.* EXCEPT (locale),
+    CASE
+      WHEN locale IS NOT NULL
+        AND languages.language_name IS NULL
+        THEN 'Other'
+      ELSE languages.language_name
+    END AS language_name,
+  FROM
+    baseline_attribution_data
+  LEFT JOIN
+    `mozdata.static.csa_gblmkt_languages` AS languages
+  ON
+    baseline_attribution_data.locale = languages.code
+),
+
+final_attribution_data AS (SELECT
+  segment,
+  app_version,
+  attribution_medium,
+  attribution_source,
+  attributed,
+  city,
+  country,
+  distribution_id,
+  first_seen_year,
+  is_default_browser,
+  app_name,
+  channel,
+  os,
+  os_version,
+  os_version_major,
+  os_version_minor,
+  submission_date,
+  adjust_network,
+  install_source,
+  language_name,
+  COUNT(DISTINCT IF(days_since_seen = 0, client_id, NULL)) AS dau,
+  COUNT(DISTINCT IF(days_since_seen < 7, client_id, NULL)) AS wau,
+  COUNT(DISTINCT client_id) AS mau,
+  COUNT(DISTINCT IF(submission_date = first_seen_date, client_id, NULL)) AS new_profiles,
+  SUM(ad_click) AS ad_clicks,
+  SUM(organic_search_count) AS organic_search_count,
+  SUM(search_count) AS search_count,
+  SUM(search_with_ads) AS search_with_ads,
+  SUM(uri_count) AS uri_count,
+  SUM(active_hours_sum) AS active_hours
+FROM
+  enriched_with_language
+GROUP BY
+  segment,
+  distribution_id,
+  channel,
+  os_version,
+  os_version_major,
+  os_version_minor,
+  language_name,
+  app_name,
+  app_version,
+  attributed,
+  attribution_medium,
+  attribution_source,
+  adjust_network,
+  install_source,
+  city,
+  country,
+  first_seen_year,
+  is_default_browser,
+  app_name,
+  os,
+  submission_date
+)
+
+select * from final_attribution_data


### PR DESCRIPTION
The following tables will be backfilled and renamed to `*_derived.active_users_aggregates_v2`  and swapped with *_v1 in the views.
1. `firefox_ios_derived.active_users_aggregates_v1` ---> `moz-fx-data-shared-prod.analysis.firefox_ios_aua_with_att_historical`
2. `firefox_desktop_derived.active_users_aggregates_v1` --> `moz-fx-data-shared-prod.analysis.firefox_desktop_aua_with_att_historical`
3. `fenix_derived.active_users_aggregates_v1`  --> `moz-fx-data-shared-prod.analysis.fenix_aua_with_att_historical`

The rest of the tables do not have any attribution data.  The table format change should be sufficient.