### PR TITLE
[DENG-3628] Backfill stable tables for os distro incident

### DIFF
--- a/backfill/2024-05-07-telemetry-pings-os-distro/README.md
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/README.md
@@ -15,7 +15,8 @@ See [incident doc](https://docs.google.com/document/d/1M7ageyDdS8sha0vYTbWwJrsRy
 
 The steps to backfill are:
 1. Run the affected pings through the decoder dataflow job, writing to staging tables
-2. Dedupe the staging tables and insert the stable tables
+2. Dedupe the staging tables 
+3. Insert into the stable tables (requires SRE assistance)
 
 Backfill for derived tables will be handled separately.
 
@@ -152,7 +153,7 @@ LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.main_v5` AS (
 ```
 
 The generated script is in [`dedupe_pings.sql`](dedupe_pings.sql).  Note: this will cost a lot less if run 
-with on-demand pricing.
+with on-demand pricing (4.4 TB vs. 2945 slot hours).
 
 Final counts:
 

--- a/backfill/2024-05-07-telemetry-pings-os-distro/README.md
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/README.md
@@ -127,7 +127,8 @@ LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.main_v5` AS (
     FROM
       `moz-fx-data-shared-prod.telemetry_stable.main_v5`
     WHERE 
-      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+      -- look for days after 2024-05-01 to account for late-arriving duplicates
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-07'
   ),
   new_rows AS (
     SELECT 
@@ -159,18 +160,18 @@ Final counts:
 
 | table                         | raw count | deduped count |
 |-------------------------------|-----------|---------------|
-| event_v4                      | 	15919980 | 15860174      | 
-| main_v5                       | 	9065904  | 9028130       | 
-| main_use_counter_v4           | 	9065904  | 9028130       | 
-| sync_v4                       | 	3022285  | 3009242       | 
-| bhr_v4                        | 	813634   | 812862        | 
-| modules_v4                    | 	454503   | 454019        | 
-| new_profile_v4                | 	228295   | 227591        | 
-| crash_v4                      | 	220374   | 220142        | 
-| first_shutdown_use_counter_v4 | 	174975   | 174493        | 
-| first_shutdown_v5             | 	174975   | 174493        | 
-| update_v4                     | 	34881    | 34542         | 
-| heartbeat_v4                  | 	3119     | 3019          |
+| event_v4                      | 	15919980 | 15859467      |
+| main_v5                       | 	9065904  | 9027807       |
+| main_use_counter_v4           | 	9065904  | 9027807       |
+| sync_v4                       | 	3022285  | 3009154       |
+| bhr_v4                        | 	813634   | 812862        |
+| modules_v4                    | 	454503   | 454019        |
+| new_profile_v4                | 	228295   | 227583        |
+| crash_v4                      | 	220374   | 220141        |
+| first_shutdown_use_counter_v4 | 	174975   | 174488        |
+| first_shutdown_v5             | 	174975   | 174488        |
+| update_v4                     | 	34881    | 34533         |
+| heartbeat_v4                  | 	3119     | 3017          |
 
 Final insert:
 ```sql

--- a/backfill/2024-05-07-telemetry-pings-os-distro/README.md
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/README.md
@@ -181,7 +181,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_v5`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 ```
 
 The generated script is in [`final_insert.sql`](final_insert.sql).

--- a/backfill/2024-05-07-telemetry-pings-os-distro/README.md
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/README.md
@@ -1,0 +1,183 @@
+# 2024-05-07 telemetry-pings-os-distro
+
+On 2024-01-12, `distro` and `distroVersion` fields were added to `environment.system.os` in the legacy telemetry ping schema
+and the sync ping schema in [this PR](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/799).
+This schema requires `distro` and `distroVersion` to be a non-null string if it is included in the payload.
+On 2024-01-16, the associated changes landed in Firefox ([bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1874038)).
+The implementation didn't correctly pull the value for Arch Linux clients resulting in the `null` value being sent.
+These pings (~340k per day) were then all dropped due to failing schema validation.
+
+A fix [for Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1894412) and 
+[the schemas](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/810) 
+were made on 2024-05-01.  We want to backfill the affected pings.
+
+See [incident doc](https://docs.google.com/document/d/1M7ageyDdS8sha0vYTbWwJrsRylrJgUYArjogCpHeL2Q/) for more details.
+
+The steps to backfill are:
+1. Run the affected pings through the decoder dataflow job, writing to staging tables
+2. Dedupe the staging tables and insert the stable tables
+
+Backfill for derived tables will be handled separately.
+
+## Affected Pings
+
+To find the affected ping volume and dates, we can look in `payload_bytes_error.telemetry`:
+
+```sql
+SELECT
+  DATE(submission_timestamp) AS d,
+  COUNT(*),
+FROM
+  `moz-fx-data-shared-prod.payload_bytes_error.telemetry`
+WHERE
+  DATE(submission_timestamp) BETWEEN "2024-01-05" AND "2024-05-04"
+  AND (
+    error_message LIKE 'org.everit.json.schema.ValidationException: #/payload/os/distro%: expected type: String, found: Null'
+    OR error_message LIKE 'org.everit.json.schema.ValidationException: #/environment/system/os/distro%: expected type: String, found: Null'
+  )
+GROUP BY d
+ORDER BY d
+
+SELECT
+  document_type,
+  COUNT(*),
+FROM
+  `moz-fx-data-shared-prod.payload_bytes_error.telemetry`
+WHERE
+  DATE(submission_timestamp) BETWEEN "2024-01-05" AND "2024-05-04"
+  AND (
+    error_message LIKE 'org.everit.json.schema.ValidationException: #/payload/os/distro%: expected type: String, found: Null'
+    OR error_message LIKE 'org.everit.json.schema.ValidationException: #/environment/system/os/distro%: expected type: String, found: Null'
+  )
+GROUP BY
+  document_type
+ORDER BY
+  2 DESC
+```
+
+The pings range from 2024-01-16 to 2024-05-01 with the following counts:
+
+| doctype   | error count |
+|-----------|-------------|
+| event     | 16378606    |
+| main      | 9223339     |
+| sync      | 3022388     |
+| bhr       | 813713      |
+| modules   | 458184      |
+| new       | 235104      |
+| crash     | 220449      |
+| first     | 179860      |
+| update    | 34881       |
+| heartbeat | 3266        |
+
+## Reingest Using Decoder
+
+To start, we need to create the temporary datasets and tables to use as dataflow input, output, and error.
+We can do that by running the script at 
+[`mirror-prod-tables.sh`](mirror-prod-tables.sh).
+
+This will create the datasets `telemetry_os_distro_output`, `telemetry_os_distro_deduped`, and 
+`payload_bytes_error_os_distro`.
+
+We will then create a `payload_bytes_error`-like table with only the rows that we want to reprocess:
+
+```sql
+CREATE TABLE 
+    moz-fx-data-backfill-1.payload_bytes_error_os_distro.telemetry_input
+LIKE 
+    moz-fx-data-backfill-1.payload_bytes_error_os_distro.telemetry
+AS
+(
+  SELECT 
+    *
+  FROM 
+    `moz-fx-data-shared-prod.payload_bytes_error.telemetry` 
+  WHERE 
+    DATE(submission_timestamp) BETWEEN "2024-01-16" AND "2024-05-01"
+    AND (
+      error_message LIKE 'org.everit.json.schema.ValidationException: #/payload/os/%: expected type: String, found: Null'
+      OR error_message LIKE 'org.everit.json.schema.ValidationException: #/environment/system/os/%: expected type: String, found: Null'
+    )
+)
+```
+
+The script in [start_dataflow.sh](start_dataflow.sh)
+will start the dataflow job when run from the `ingestion-beam/` directory in 
+[`gcp-ingestion`](https://github.com/mozilla/gcp-ingestion/tree/main/ingestion-beam).
+`gcloud config set project moz-fx-data-backfill-1` may be needed.  
+The job will be viewable at https://console.cloud.google.com/dataflow/jobs?project=moz-fx-data-backfill-1
+
+## Dedupe and Insert
+
+The dataflow output will have duplicate document ids, so we need to dedupe before inserting into the stable tables,
+similar to copy_deduplicate. We can also check if any document ids already exist in the stable table as a safeguard
+if we run the insert twice. There are no automation pings so there's no need to filter like in copy_deduplicate.
+
+This will be split into two steps for easier validation.  [`generate_statements.py`](generate_statements.py) will generate
+the sql needed.
+
+We can dedupe and insert into a staging table with a statement like:
+```sql
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_v5` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.main_v5` AS (
+SELECT 
+  * 
+FROM 
+  `moz-fx-data-backfill-1.telemetry_os_distro_output.main_v5` 
+QUALIFY 
+  ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+); 
+```
+
+The generated script is in [`dedupe_pings.sql`](dedupe_pings.sql).
+
+Final counts:
+
+| table                         | raw count | deduped count |
+|-------------------------------|-----------|---------------|
+| event_v4                      | 	15919980 | 15860174      | 
+| main_v5                       | 	9065904  | 9028130       | 
+| main_use_counter_v4           | 	9065904  | 9028130       | 
+| sync_v4                       | 	3022285  | 3009242       | 
+| bhr_v4                        | 	813634   | 812862        | 
+| modules_v4                    | 	454503   | 454019        | 
+| new_profile_v4                | 	228295   | 227591        | 
+| crash_v4                      | 	220374   | 220142        | 
+| first_shutdown_use_counter_v4 | 	174975   | 174493        | 
+| first_shutdown_v5             | 	174975   | 174493        | 
+| update_v4                     | 	34881    | 34542         | 
+| heartbeat_v4                  | 	3119     | 3019          |
+
+Final insert:
+```sql
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.main_v5`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.main_v5`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_v5`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+```
+
+The generated script is in [`final_insert.sql`](final_insert.sql).

--- a/backfill/2024-05-07-telemetry-pings-os-distro/dedupe_pings.sql
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/dedupe_pings.sql
@@ -1,0 +1,95 @@
+-- bhr_v4
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.bhr_v4` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.bhr_v4` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.bhr_v4`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- crash_v4
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.crash_v4` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.crash_v4` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.crash_v4`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- event_v4
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.event_v4` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.event_v4` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.event_v4`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- first_shutdown_use_counter_v4
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_use_counter_v4` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.first_shutdown_use_counter_v4` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.first_shutdown_use_counter_v4`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- first_shutdown_v5
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_v5` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.first_shutdown_v5` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.first_shutdown_v5`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- heartbeat_v4
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.heartbeat_v4` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.heartbeat_v4` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.heartbeat_v4`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- main_use_counter_v4
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_use_counter_v4` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.main_use_counter_v4` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.main_use_counter_v4`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- main_v5
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_v5` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.main_v5` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.main_v5`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- modules_v4
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.modules_v4` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.modules_v4` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.modules_v4`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- new_profile_v4
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.new_profile_v4` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.new_profile_v4` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.new_profile_v4`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- sync_v4
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.sync_v4` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.sync_v4` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.sync_v4`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+
+-- update_v4
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.update_v4` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.update_v4` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.update_v4`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);

--- a/backfill/2024-05-07-telemetry-pings-os-distro/dedupe_pings.sql
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/dedupe_pings.sql
@@ -1,95 +1,395 @@
 -- bhr_v4
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.bhr_v4` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.bhr_v4`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.bhr_v4` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.bhr_v4`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.bhr_v4`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.bhr_v4` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- crash_v4
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.crash_v4` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.crash_v4`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.crash_v4` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.crash_v4`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.crash_v4`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.crash_v4` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- event_v4
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.event_v4` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.event_v4`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.event_v4` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.event_v4`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.event_v4`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.event_v4` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- first_shutdown_use_counter_v4
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_use_counter_v4` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_use_counter_v4`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.first_shutdown_use_counter_v4` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.first_shutdown_use_counter_v4`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_use_counter_v4`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.first_shutdown_use_counter_v4` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- first_shutdown_v5
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_v5` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_v5`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.first_shutdown_v5` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.first_shutdown_v5`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_v5`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.first_shutdown_v5` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- heartbeat_v4
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.heartbeat_v4` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.heartbeat_v4`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.heartbeat_v4` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.heartbeat_v4`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.heartbeat_v4`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.heartbeat_v4` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- main_use_counter_v4
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_use_counter_v4` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_use_counter_v4`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.main_use_counter_v4` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.main_use_counter_v4`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.main_use_counter_v4`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.main_use_counter_v4` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- main_v5
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_v5` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_v5`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.main_v5` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.main_v5`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.main_v5`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.main_v5` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- modules_v4
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.modules_v4` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.modules_v4`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.modules_v4` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.modules_v4`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.modules_v4`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.modules_v4` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- new_profile_v4
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.new_profile_v4` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.new_profile_v4`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.new_profile_v4` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.new_profile_v4`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.new_profile_v4`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.new_profile_v4` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- sync_v4
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.sync_v4` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.sync_v4`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.sync_v4` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.sync_v4`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.sync_v4`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.sync_v4` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 
 -- update_v4
-CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.update_v4` 
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.update_v4`
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.update_v4` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.update_v4`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.update_v4`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.update_v4` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );

--- a/backfill/2024-05-07-telemetry-pings-os-distro/final_insert.sql
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/final_insert.sql
@@ -1,359 +1,119 @@
 -- bhr_v4
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.bhr_v4`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.bhr_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.bhr_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.bhr_v4`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- crash_v4
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.crash_v4`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.crash_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.crash_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.crash_v4`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- event_v4
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.event_v4`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.event_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.event_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.event_v4`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- first_shutdown_use_counter_v4
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_use_counter_v4`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_use_counter_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_use_counter_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_use_counter_v4`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- first_shutdown_v5
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_v5`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_v5`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_v5`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_v5`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- heartbeat_v4
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.heartbeat_v4`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.heartbeat_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.heartbeat_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.heartbeat_v4`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- main_use_counter_v4
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.main_use_counter_v4`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.main_use_counter_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_use_counter_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_use_counter_v4`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- main_v5
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.main_v5`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.main_v5`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_v5`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_v5`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- modules_v4
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.modules_v4`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.modules_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.modules_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.modules_v4`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- new_profile_v4
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.new_profile_v4`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.new_profile_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.new_profile_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.new_profile_v4`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- sync_v4
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.sync_v4`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.sync_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.sync_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.sync_v4`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 
 -- update_v4
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.update_v4`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.update_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.update_v4`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.update_v4`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'

--- a/backfill/2024-05-07-telemetry-pings-os-distro/final_insert.sql
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/final_insert.sql
@@ -6,7 +6,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.bhr_v4`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- crash_v4
 INSERT INTO
@@ -16,7 +16,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.crash_v4`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- event_v4
 INSERT INTO
@@ -26,7 +26,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.event_v4`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- first_shutdown_use_counter_v4
 INSERT INTO
@@ -36,7 +36,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_use_counter_v4`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- first_shutdown_v5
 INSERT INTO
@@ -46,7 +46,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_v5`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- heartbeat_v4
 INSERT INTO
@@ -56,7 +56,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.heartbeat_v4`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- main_use_counter_v4
 INSERT INTO
@@ -66,7 +66,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_use_counter_v4`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- main_v5
 INSERT INTO
@@ -76,7 +76,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_v5`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- modules_v4
 INSERT INTO
@@ -86,7 +86,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.modules_v4`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- new_profile_v4
 INSERT INTO
@@ -96,7 +96,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.new_profile_v4`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- sync_v4
 INSERT INTO
@@ -106,7 +106,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.sync_v4`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 
 -- update_v4
 INSERT INTO
@@ -116,4 +116,4 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.update_v4`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';

--- a/backfill/2024-05-07-telemetry-pings-os-distro/final_insert.sql
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/final_insert.sql
@@ -1,0 +1,359 @@
+-- bhr_v4
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.bhr_v4`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.bhr_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.bhr_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- crash_v4
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.crash_v4`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.crash_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.crash_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- event_v4
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.event_v4`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.event_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.event_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- first_shutdown_use_counter_v4
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_use_counter_v4`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_use_counter_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_use_counter_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- first_shutdown_v5
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_v5`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.first_shutdown_v5`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.first_shutdown_v5`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- heartbeat_v4
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.heartbeat_v4`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.heartbeat_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.heartbeat_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- main_use_counter_v4
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.main_use_counter_v4`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.main_use_counter_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_use_counter_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- main_v5
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.main_v5`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.main_v5`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.main_v5`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- modules_v4
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.modules_v4`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.modules_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.modules_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- new_profile_v4
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.new_profile_v4`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.new_profile_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.new_profile_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- sync_v4
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.sync_v4`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.sync_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.sync_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+
+-- update_v4
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.update_v4`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.update_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.update_v4`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;

--- a/backfill/2024-05-07-telemetry-pings-os-distro/generate_statements.py
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/generate_statements.py
@@ -1,0 +1,71 @@
+import subprocess
+
+# use bash to avoid python dependencies
+result = subprocess.check_output(
+    [
+        "bq",
+        "query",
+        "--format=sparse",
+        "--nouse_legacy_sql",
+        "--max_rows=1000",
+        "SELECT DISTINCT(_TABLE_SUFFIX) FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.*` ORDER BY 1",
+    ]
+)
+
+tables = result.decode().split()[2:]
+
+CREATE_STATEMENT_TEMPLATE = """-- {table}
+CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.{table}` 
+LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.{table}` AS (
+    SELECT *
+    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.{table}`
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+);
+"""
+
+creates = []
+
+for table in tables:
+    creates.append(CREATE_STATEMENT_TEMPLATE.format(table=table))
+
+with open("dedupe_pings.sql", "w") as f:
+    f.write("\n".join(creates))
+
+INSERT_STATEMENT_TEMPLATE = """-- {table}
+INSERT INTO
+  `moz-fx-data-shared-prod.telemetry_stable.{table}`
+WITH existing_doc_ids AS (
+  SELECT
+    document_id
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.{table}`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+),
+new_rows AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.{table}`
+  WHERE 
+    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+)
+SELECT
+  new_rows.*
+FROM
+  new_rows
+LEFT JOIN
+  existing_doc_ids
+USING
+  (document_id)
+WHERE
+  existing_doc_ids.document_id IS NULL;
+"""
+
+inserts = []
+
+for table in tables:
+    inserts.append(INSERT_STATEMENT_TEMPLATE.format(table=table))
+
+with open("final_insert.sql", "w") as f:
+    f.write("\n".join(inserts))

--- a/backfill/2024-05-07-telemetry-pings-os-distro/generate_statements.py
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/generate_statements.py
@@ -17,9 +17,34 @@ tables = result.decode().split()[2:]
 CREATE_STATEMENT_TEMPLATE = """-- {table}
 CREATE TABLE `moz-fx-data-backfill-1.telemetry_os_distro_deduped.{table}` 
 LIKE `moz-fx-data-backfill-1.telemetry_os_distro_output.{table}` AS (
-    SELECT *
-    FROM `moz-fx-data-backfill-1.telemetry_os_distro_output.{table}`
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  WITH existing_doc_ids AS (
+    SELECT
+      document_id
+    FROM
+      `moz-fx-data-shared-prod.telemetry_stable.{table}`
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  ),
+  new_rows AS (
+    SELECT 
+      * 
+    FROM 
+      `moz-fx-data-backfill-1.telemetry_os_distro_output.{table}` 
+    WHERE 
+      DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+    QUALIFY 
+      ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) = 1
+  )
+  SELECT
+    new_rows.*
+  FROM
+    new_rows
+  LEFT JOIN
+    existing_doc_ids
+  USING
+    (document_id)
+  WHERE
+    existing_doc_ids.document_id IS NULL
 );
 """
 
@@ -34,32 +59,12 @@ with open("dedupe_pings.sql", "w") as f:
 INSERT_STATEMENT_TEMPLATE = """-- {table}
 INSERT INTO
   `moz-fx-data-shared-prod.telemetry_stable.{table}`
-WITH existing_doc_ids AS (
-  SELECT
-    document_id
-  FROM
-    `moz-fx-data-shared-prod.telemetry_stable.{table}`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-),
-new_rows AS (
-  SELECT
-    *
-  FROM
-    `moz-fx-data-backfill-1.telemetry_os_distro_deduped.{table}`
-  WHERE 
-    DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
-)
 SELECT
-  new_rows.*
+  *
 FROM
-  new_rows
-LEFT JOIN
-  existing_doc_ids
-USING
-  (document_id)
-WHERE
-  existing_doc_ids.document_id IS NULL;
+  `moz-fx-data-backfill-1.telemetry_os_distro_deduped.{table}`
+WHERE 
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
 """
 
 inserts = []

--- a/backfill/2024-05-07-telemetry-pings-os-distro/generate_statements.py
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/generate_statements.py
@@ -64,7 +64,7 @@ SELECT
 FROM
   `moz-fx-data-backfill-1.telemetry_os_distro_deduped.{table}`
 WHERE 
-  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02'
+  DATE(submission_timestamp) BETWEEN '2024-01-16' AND '2024-05-02';
 """
 
 inserts = []

--- a/backfill/2024-05-07-telemetry-pings-os-distro/mirror-prod-tables.sh
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/mirror-prod-tables.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+PROJECT=moz-fx-data-backfill-1
+
+# Create staging datasets and tables, copying schemas from stable tables
+# telemetry_os_distro_output is for the dataflow output, telemetry_os_distro_deduped is the deduped output
+
+src_dataset=telemetry_stable
+output_dataset=telemetry_os_distro_output
+deduped_dataset=telemetry_os_distro_deduped
+
+bq mk $PROJECT:$output_dataset
+bq mk $PROJECT:$deduped_dataset
+
+# use bq mk instead of CREATE TABLE LIKE because some tables we need have restricted read access, e.g. main_v4
+# we don't need these tables but this is easier than hardcoding the ones we need since doctype to table isn't 1:1
+# also to not have partition filter requirement
+for table in $(bq ls -n 1000 --project_id=moz-fx-data-shared-prod "$src_dataset" | tail -n+3 | awk '{print $1}' | grep -E '_v'); do
+  bq show --format=json "moz-fx-data-shared-prod:$src_dataset.$table" | jq '.schema.fields' > table.json
+  bq mk -t \
+     --time_partitioning_field=submission_timestamp \
+     --clustering_fields=normalized_channel,sample_id \
+     --table "$PROJECT:$output_dataset.$table" \
+     table.json
+done
+
+# Create an error table for dataflow
+
+pbr_dataset=payload_bytes_error_os_distro
+
+bq mk $PROJECT:$pbr_dataset
+
+bq show --format=json "moz-fx-data-shared-prod:payload_bytes_error.telemetry" | jq '.schema.fields' > table.json
+bq mk -t \
+   --time_partitioning_field=submission_timestamp \
+   --clustering_fields=submission_timestamp \
+   --table "$PROJECT:$pbr_dataset.telemetry" \
+   table.json

--- a/backfill/2024-05-07-telemetry-pings-os-distro/start_dataflow.sh
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/start_dataflow.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -exo pipefail
+
+PROJECT="moz-fx-data-backfill-1"
+JOB_NAME="telemetry-os-distro-backfill-1"
+
+# this script assumes it's being run from the ingestion-beam directory
+# of the gcp-ingestion repo.
+
+mvn compile exec:java -Dexec.mainClass=com.mozilla.telemetry.Decoder -Dmaven.compiler.release=11 -Dexec.args="\
+    --runner=Dataflow \
+    --jobName=$JOB_NAME \
+    --project=$PROJECT  \
+    --geoCityDatabase=gs://moz-fx-data-prod-geoip/GeoIP2-City/20240430/GeoIP2-City.mmdb \
+    --geoCityFilter=gs://moz-fx-data-prod-dataflow-templates/cities15000.txt \
+    --geoIspDatabase=gs://moz-fx-data-prod-geoip/GeoIP2-ISP/20240430/GeoIP2-ISP.mmdb \
+    --schemasLocation=gs://moz-fx-data-prod-dataflow/schemas/202405020245_10116618.tar.gz \
+    --inputType=bigquery_table \
+    --input='$PROJECT:payload_bytes_error_os_distro.telemetry_input' \
+    --bqReadMethod=storageapi \
+    --outputType=bigquery \
+    --bqWriteMethod=file_loads \
+    --bqClusteringFields=normalized_channel,sample_id \
+    --output=${PROJECT}:telemetry_os_distro_output.\${document_type}_v\${document_version} \
+    --errorOutputType=bigquery \
+    --errorOutput=${PROJECT}:payload_bytes_error_os_distro.telemetry \
+    --experiments=shuffle_mode=service \
+    --region=us-central1 \
+    --usePublicIps=false \
+    --gcsUploadBufferSizeBytes=16777216 \
+    --tempLocation=gs://dataflow-staging-us-central1-215736861657/temp/ \
+    --numWorkers=5 \
+    --maxNumWorkers=200 \
+"

--- a/backfill/2024-05-07-telemetry-pings-os-distro/table.json
+++ b/backfill/2024-05-07-telemetry-pings-os-distro/table.json
@@ -1,0 +1,1 @@
+"placeholder"


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-3628

Ping table backfill from 2024-01-16 to 2024-05-01 using payload_bytes_error following https://docs.google.com/document/d/1M7ageyDdS8sha0vYTbWwJrsRylrJgUYArjogCpHeL2Q/

Steps are
payload_bytes_error -> decoder -> output_tables -> deduped_tables -> stable_tables