### PR TITLE
Extend metrics ping window

### DIFF
--- a/backfill/2024-04-26-active_users_aggregates/fenix_query.sql
+++ b/backfill/2024-04-26-active_users_aggregates/fenix_query.sql
@@ -10,7 +10,7 @@ WITH distribution_id AS
   FROM
     `moz-fx-data-shared-prod.fenix.metrics`
   WHERE
-    DATE(submission_timestamp) BETWEEN @submission_date AND DATE_ADD(@submission_date, INTERVAL 7 DAY)
+    DATE(submission_timestamp) BETWEEN DATE_SUB(@submission_date, INTERVAL 7 DAY) AND DATE_ADD(@submission_date, INTERVAL 7 DAY)
   GROUP BY
     client_id
 ),


### PR DESCRIPTION
Extending the window to query metrics pings from the previous 7 days to get distribution_id on the last active day in case the user doesn't send a metrics ping on that day.